### PR TITLE
Add support for installation via `mip`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "urls": [
+        [
+            "mpy_decimal.py",
+            "github:mpy-dev/micropython-decimal-number/mpy_decimal/mpy_decimal.py"
+        ]
+    ],
+    "deps": [],
+    "version": "1.0"
+}


### PR DESCRIPTION
This change adds support for installation of `mpy_decimal` via the [mip command](https://docs.micropython.org/en/latest/reference/packages.html). This is very convenient for modern package management within the MicroPython ecosystem.

This would allow the package to be installed via: `mip install github:mpy-dev/micropython-decimal-number`