### PR TITLE
updated for CircuitPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Decimal floating point arithmetic for micropython
-This Python module for [*micropython*](https://micropython.org/) provides support for decimal floating point arithmetic. It tries to overcome the limitations of single precision float numbers (32-bit) and provides a solution when double precision float numbers (64 bit) are not enough.
+This Python module for [*micropython*](https://micropython.org/) and [*CircuitPython*](https://circuitpython.org/) provides support for decimal floating point arithmetic. It tries to overcome the limitations of single precision float numbers (32-bit) and provides a solution when double precision float numbers (64 bit) are not enough.
 
 The Python Standard Library contains the wonderful module [*decimal*](https://docs.python.org/3/library/decimal.html), but it has not been ported to *micropython*. This module provides a small, but valuable, part of the functionality of *decimal*.
 

--- a/mpy_decimal/mpy_decimal.py
+++ b/mpy_decimal/mpy_decimal.py
@@ -4,12 +4,14 @@ if sys.implementation.name == "cpython":        # micropython does not include '
     from typing import Tuple
 if sys.implementation.name == "micropython":    # Just in case...
     pass
+if sys.implementation.name == "circuitpython":    # Also just in case...
+    pass
 
 
 class DecimalNumber:
     """DecimalNumber is a class for decimal floating point arithmetic with arbitrary precision."""
-    VERSION = (1, 0, 0)
-    VERSION_NAME = "v1.0.0 - August 2021"
+    VERSION = (1, 0, 1)
+    VERSION_NAME = "v1.0.1 - September 2025"
     DEFAULT_SCALE: int = 16
     DECIMAL_SEP: str = "."
     THOUSANDS_SEP: str = ","
@@ -1101,3 +1103,4 @@ class DecimalNumberExceptionDivisionByZeroError(DecimalNumberException):
 
 if __name__ == "__main__":
     print("DecimalNumber module -", DecimalNumber.VERSION)
+

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
     "urls": [
         [
             "decimal.py",
-            "github:scruss/micropython-decimal-number/mpy_decimal/decimal.py"
+            "github:scruss/micropython-decimal-number/mpy_decimal/mpy_decimal.py"
         ]
     ],
     "deps": [],
-    "version": "1.0.1"
+    "version": "1.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "urls": [
         [
             "decimal.py",
-            "github:scruss/micropython-decimal/mpy_decimal/decimal.py"
+            "github:scruss/micropython-decimal-number/mpy_decimal/decimal.py"
         ]
     ],
     "deps": [],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "urls": [
+        [
+            "decimal.py",
+            "github:scruss/micropython-decimal/mpy_decimal/decimal.py"
+        ]
+    ],
+    "deps": [],
+    "version": "1.0.1"
+}

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup, find_packages
 
 setup (
     name = 'Micropython DecimalNumber',
-    version = '1.0',
+    version = '1.0.1',
     packages = find_packages()
 )

--- a/tests/perf_decimal_number.py
+++ b/tests/perf_decimal_number.py
@@ -11,7 +11,13 @@ if sys.implementation.name == "cpython":
     pi_decimals: int = 1000
 if sys.implementation.name == "micropython":
     import machine
-    import utime
+    import time
+    iteration_limit: int = 1000
+    iteration_limit2: int = 400
+    pi_decimals: int = 300
+if sys.implementation.name == "circuitpython":
+    import microcontroller
+    import supervisor
     iteration_limit: int = 1000
     iteration_limit2: int = 400
     pi_decimals: int = 300
@@ -32,6 +38,9 @@ def system_machine_info() -> None:
     if sys.implementation.name == "micropython":
         print(format_str.format("CPU frequency:"),
               machine.freq() // 1000000, "Mhz")
+    if sys.implementation.name == "circuitpython":
+        print(format_str.format("CPU frequency:"),
+              microcontroller.cpu.frequency // 1000000, "Mhz")
 
 def get_time_ms() -> int:
     """It gets the time in miliseconds.
@@ -39,7 +48,9 @@ def get_time_ms() -> int:
     if sys.implementation.name == "cpython":
         return round(time.time() * 1000)
     if sys.implementation.name == "micropython":
-        return utime.ticks_ms()
+        return time.ticks_ms()
+    if sys.implementation.name == "circuitpython":
+        return supervisor.ticks_ms()
 
 def gen_random_number() -> DecimalNumber:
     """Generates a random number with a number of decimals equal to scale.
@@ -249,3 +260,4 @@ perf_decimal_number(iteration_limit2, iteration_limit2 // 100)
 
 print_title("CALCULATING PI")
 perf_decimal_number_pi()
+

--- a/tests/test_decimal_number.py
+++ b/tests/test_decimal_number.py
@@ -6,6 +6,8 @@ if sys.implementation.name == "cpython":
     import traceback
 if sys.implementation.name == "micropython":
     pass
+if sys.implementation.name == "circuitpython":
+    pass
 
 
 class TestDecimalNumber():
@@ -1407,3 +1409,4 @@ if __name__ == "__main__":
         print("Result: 1 test failed")
     else:
         print("Result: {0} tests failed".format(failed_counter))
+


### PR DESCRIPTION
Your library already worked well with [CircuitPython](https://circuitpython.org/), but the test code needed some tweaking.

I also updated the MicroPython side by removing references to utime and adding Oliver's `mip` support.